### PR TITLE
add implementation of connectionTimeout field

### DIFF
--- a/lib/src/http_client.dart
+++ b/lib/src/http_client.dart
@@ -16,6 +16,9 @@ class StethoHttpClient implements HttpClient {
 
   @override
   Duration idleTimeout;
+  
+  @override
+  Duration connectionTimeout;
 
   @override
   int maxConnectionsPerHost;


### PR DESCRIPTION
or, will get this error:

``` dart
compiler message:   'connectionTimeout', 'connectionTimeout='.
compiler message: Try to either
compiler message:  - provide an implementation,
compiler message:  - inherit an implementation from a superclass or mixin,
compiler message:  - mark the class as abstract, or
compiler message:  - provide a 'noSuchMethod' implementation.
compiler message: 
compiler message: class StethoHttpClient implements HttpClient {
compiler message:       ^^^^^^^^^^^^^^^^
compiler message: file:///b/build/slave/Linux_Engine/build/src/third_party/dart/sdk/lib/_http/http.dart:1: Error: 'connectionTimeout' is defined here.
compiler message: file:///b/build/slave/Linux_Engine/build/src/third_party/dart/sdk/lib/_http/http.dart:1: Error: 'connectionTimeout=' is defined here.
Compiler terminated unexpectedly.
```
