### PR TITLE
Provide OptIn feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Note: It's probably a good idea only put this override in [a `main_dev.dart` fil
 
 ```dart
 void main() {
-  HttpOverrides.global = new StethoHttpOverrides();
+  Stetho.initialize();
 
   runApp(new MyApp());
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:flutter_stetho/flutter_stetho.dart';
 import 'package:http/http.dart' as http;
 
 void main() {
-  HttpOverrides.global = new StethoHttpOverrides();
+  Stetho.initialize();
 
   runApp(new FlutterStethoExample(
     client: new http.Client(),

--- a/lib/flutter_stetho.dart
+++ b/lib/flutter_stetho.dart
@@ -1,3 +1,3 @@
 library flutter_stetho;
 
-export 'src/http_overrides.dart';
+export 'src/stetho.dart';

--- a/lib/src/method_channel_controller.dart
+++ b/lib/src/method_channel_controller.dart
@@ -29,4 +29,6 @@ class MethodChannelController {
 
   static Future<dynamic> onDone(String id) =>
       _channel.invokeMethod('onDone', id);
+
+  static Future<dynamic> initialize() => _channel.invokeMethod('initialize');
 }

--- a/lib/src/stetho.dart
+++ b/lib/src/stetho.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_stetho/src/method_channel_controller.dart';
+import 'package:flutter_stetho/src/http_overrides.dart';
+
+class Stetho {
+
+  static Future<void> initialize() {
+    if (Platform.isAndroid) {
+      HttpOverrides.global = StethoHttpOverrides();
+
+      return MethodChannelController.initialize();
+    }
+
+    return Future.value();
+  }
+
+}


### PR DESCRIPTION
Currently the basic feature set of stetho is enabled
whenever the plugin is added to the project.

This includes Database and the Shared Preference access.
This proves to be quite dangerous for the production builds.