### PR TITLE
Allow modification of Request fields after it is created

### DIFF
--- a/lib/src/http_client.dart
+++ b/lib/src/http_client.dart
@@ -149,15 +149,6 @@ class StethoHttpClient implements HttpClient {
   StethoHttpClientRequest _wrapResponse(HttpClientRequest request) {
     final id = new Uuid().generateV4();
 
-    return new StethoHttpClientRequest(
-      request,
-      id,
-      request.bufferOutput,
-      request.contentLength,
-      request.encoding,
-      request.followRedirects,
-      request.maxRedirects,
-      request.persistentConnection,
-    );
+    return new StethoHttpClientRequest(request, id);
   }
 }

--- a/lib/src/http_client_request.dart
+++ b/lib/src/http_client_request.dart
@@ -11,33 +11,9 @@ class StethoHttpClientRequest implements HttpClientRequest {
   final HttpClientRequest request;
   final String id;
 
-  @override
-  bool bufferOutput;
-
-  @override
-  int contentLength;
-
-  @override
-  Encoding encoding;
-
-  @override
-  bool followRedirects;
-
-  @override
-  int maxRedirects;
-
-  @override
-  bool persistentConnection;
-
   StethoHttpClientRequest(
     this.request,
     this.id,
-    this.bufferOutput,
-    this.contentLength,
-    this.encoding,
-    this.followRedirects,
-    this.maxRedirects,
-    this.persistentConnection,
   );
 
   @override
@@ -78,6 +54,44 @@ class StethoHttpClientRequest implements HttpClientRequest {
       response.transform(createResponseTransformer(id)),
     );
   }
+
+  @override
+  bool get bufferOutput => request.bufferOutput;
+
+  @override
+  set bufferOutput(bool bufferOutput) => request.bufferOutput = bufferOutput;
+
+  @override
+  int get contentLength => request.contentLength;
+
+  @override
+  set contentLength(int contentLength) => request.contentLength = contentLength;
+
+  @override
+  Encoding get encoding => request.encoding;
+
+  @override
+  set encoding(Encoding encoding) => request.encoding = encoding;
+
+  @override
+  bool get followRedirects => request.followRedirects;
+
+  @override
+  set followRedirects(bool followRedirects) =>
+      request.followRedirects = followRedirects;
+
+  @override
+  int get maxRedirects => request.maxRedirects;
+
+  @override
+  set maxRedirects(int maxRedirects) => request.maxRedirects = maxRedirects;
+
+  @override
+  bool get persistentConnection => request.persistentConnection;
+
+  @override
+  set persistentConnection(bool persistentConnection) =>
+      request.persistentConnection = persistentConnection;
 
   @override
   HttpConnectionInfo get connectionInfo => request.connectionInfo;


### PR DESCRIPTION
This is a fix for No `contentLength` sent in POST method #16 issue.
When we create `StethoHttpClientRequest` we set contentLength and other fields.
Unfortunately, `HttpClientRequest` is mutable and some fields are set later by the framework (for example `contentLength`).
Because of the underlying `HttpClientRequest` not being updated, we no longer send the updated `contentLength` to the server