### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/src/http_client_request.dart
+++ b/lib/src/http_client_request.dart
@@ -75,7 +75,7 @@ class StethoHttpClientRequest implements HttpClientRequest {
 
     return new StethoHttpClientResponse(
       response,
-      response.transform(createResponseTransformer(id)),
+      createResponseTransformer(id).bind(response),
     );
   }
 


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
