### PR TITLE
Fix dev / master types for new version of Dart

### DIFF
--- a/lib/src/http_client_response.dart
+++ b/lib/src/http_client_response.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
-class StethoHttpClientResponse extends StreamView<List<int>>
+class StethoHttpClientResponse extends StreamView<Uint8List>
     implements HttpClientResponse {
   final HttpClientResponse response;
 
-  StethoHttpClientResponse(this.response, Stream<List<int>> stream)
+  StethoHttpClientResponse(this.response, Stream<Uint8List> stream)
       : super(stream);
 
   @override

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
 import 'dart:io';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:flutter_stetho/src/method_channel_controller.dart';
 
 /// Create a response transformer that can intercept and pipe the http response
 /// data to the Method channel
-StreamTransformer<List<int>, List<int>> createResponseTransformer(String id) {
+StreamTransformer<Uint8List, Uint8List> createResponseTransformer(String id) {
   return new StreamTransformer.fromHandlers(handleData: (data, sink) {
     sink.add(data);
     MethodChannelController.onData({"data": data, "id": id});


### PR DESCRIPTION
Uses `Uint8List` instead of `List<int>` for newer versions of Dart

Fixes #25 